### PR TITLE
feat: implement Get /word?q= lookup with search_count tracking (#8)

### DIFF
--- a/server/src/modules/vocabulary/__tests__/vocabulary.route.test.ts
+++ b/server/src/modules/vocabulary/__tests__/vocabulary.route.test.ts
@@ -48,3 +48,57 @@ describe("POST /word", () => {
     expect(res.status).toBe(400);
   });
 });
+
+describe('GET /word', () => {
+
+  it('trả về từ khi tìm thấy', async () => {
+    // Mock getDB trả về từ hợp lệ
+    const { getDB } = require('../../../config/db');
+    getDB.mockReturnValue({
+      collection: jest.fn().mockReturnValue({
+        insertOne: jest.fn().mockResolvedValue({ insertedId: '123' }),
+        findOne: jest.fn().mockResolvedValue({
+          word: 'apple', meaning: 'a fruit', search_count: 0
+        }),
+        updateOne: jest.fn().mockResolvedValue({}),
+      })
+    });
+
+    const res = await request(app)
+      .get('/api/word?q=apple');
+
+    expect(res.status).toBe(200);
+    expect(res.body.word).toBe('apple');
+  });
+
+  it('trả về 404 khi không tìm thấy từ', async () => {
+    const { getDB } = require('../../../config/db');
+    getDB.mockReturnValue({
+      collection: jest.fn().mockReturnValue({
+        insertOne: jest.fn().mockResolvedValue({ insertedId: '123' }),
+        findOne: jest.fn().mockResolvedValue(null),
+        updateOne: jest.fn().mockResolvedValue({}),
+      })
+    });
+
+    const res = await request(app)
+      .get('/api/word?q=notexist');
+
+    expect(res.status).toBe(404);
+  });
+
+  it('trả về 400 khi query rỗng', async () => {
+    const res = await request(app)
+      .get('/api/word?q=');
+
+    expect(res.status).toBe(400);
+  });
+
+  it('trả về 400 khi không có query', async () => {
+    const res = await request(app)
+      .get('/api/word');
+
+    expect(res.status).toBe(400);
+  });
+
+});

--- a/server/src/modules/vocabulary/__tests__/vocabulary.service.test.ts
+++ b/server/src/modules/vocabulary/__tests__/vocabulary.service.test.ts
@@ -25,3 +25,67 @@ describe("createWord", () => {
   });
 
 });
+
+import { lookupWord } from '../vocabulary.service';
+import { findWordByQuery, incrementSearchCount } from '../vocabulary.repository';
+
+jest.mock('../vocabulary.repository', () => ({
+  insertWord: jest.fn().mockResolvedValue({ id: '123', word: 'apple', meaning: 'a fruit' }),
+  findWordByQuery: jest.fn(),
+  incrementSearchCount: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockFindWord = findWordByQuery as jest.MockedFunction<typeof findWordByQuery>;
+
+describe('lookupWord', () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('trả về từ khi tìm thấy', async () => {
+    mockFindWord.mockResolvedValue({
+      _id: '1', word: 'apple', meaning: 'a fruit', search_count: 0
+    } as any);
+
+    const result = await lookupWord('apple');
+    expect(result.word).toBe('apple');
+  });
+
+  it('tăng search_count khi tìm thấy từ', async () => {
+    mockFindWord.mockResolvedValue({
+      _id: '1', word: 'apple', meaning: 'a fruit', search_count: 0
+    } as any);
+
+    await lookupWord('apple');
+    expect(incrementSearchCount).toHaveBeenCalledTimes(1);
+  });
+
+  it('throw 404 khi không tìm thấy từ', async () => {
+    mockFindWord.mockResolvedValue(null);
+
+    await expect(lookupWord('xyz123')).rejects.toMatchObject({
+      statusCode: 404
+    });
+  });
+
+  it('throw 400 khi query rỗng', async () => {
+    await expect(lookupWord('')).rejects.toMatchObject({
+      statusCode: 400
+    });
+  });
+
+  it('throw 400 khi query không phải string', async () => {
+    await expect(lookupWord(undefined)).rejects.toMatchObject({
+      statusCode: 400
+    });
+  });
+
+  it('không tăng search_count khi không tìm thấy từ', async () => {
+    mockFindWord.mockResolvedValue(null);
+
+    await expect(lookupWord('notexist')).rejects.toThrow();
+    expect(incrementSearchCount).not.toHaveBeenCalled();
+  });
+
+});

--- a/server/src/modules/vocabulary/vocabulary.repository.ts
+++ b/server/src/modules/vocabulary/vocabulary.repository.ts
@@ -16,3 +16,22 @@ export async function insertWord(word: string, meaning: string) {
     meaning
   };
 }
+
+export async function findWordByQuery(query: string) {
+  const db = getDB();
+  const collection = db.collection('vocabulary');
+
+  return collection.findOne({
+    word: { $regex: new RegExp(`^${query}$`, 'i') }
+  });
+}
+
+export async function incrementSearchCount(query: string) {
+  const db = getDB();
+  const collection = db.collection('vocabulary');
+
+  await collection.updateOne(
+    { word: { $regex: new RegExp(`^${query}$`, 'i') } },
+    { $inc: { search_count: 1 } }
+  );
+}

--- a/server/src/modules/vocabulary/vocabulary.route.ts
+++ b/server/src/modules/vocabulary/vocabulary.route.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { createWord } from "./vocabulary.service";
+import { createWord, lookupWord } from "./vocabulary.service";
 
 const router = Router();
 
@@ -21,5 +21,15 @@ router.post("/word", async (req, res) => {
 
 });
 
+router.get('/word', async (req, res) => {
+  try {
+    const result = await lookupWord(req.query.q);
+    res.status(200).json(result);
+  } catch (err: any) {
+    const status = err.statusCode ?? 400;
+    res.status(status).json({ error: err.message });
+  }
+});
 
 export default router;
+

--- a/server/src/modules/vocabulary/vocabulary.service.ts
+++ b/server/src/modules/vocabulary/vocabulary.service.ts
@@ -1,4 +1,6 @@
-import { insertWord } from "./vocabulary.repository";
+import { insertWord, findWordByQuery, incrementSearchCount } from './vocabulary.repository';
+import { validateString, normalizeWord } from '../../utils/validation';
+import { AppError } from '../../middleware/error';
 
 /* =========================
    GET ALL WORDS
@@ -22,4 +24,28 @@ export async function createWord(data: { word: string; meaning: string }) {
   }
 
   return await insertWord(word, meaning);
+}
+
+/* =========================
+   LOOKUP WORD — Issue #8
+========================= */
+export async function lookupWord(query: unknown) {
+  // 1. Validate: query không được rỗng
+  const rawQuery = validateString(query, 'query');
+
+  // 2. Normalize: lowercase, trim, bỏ ký tự đặc biệt
+  const normalized = normalizeWord(rawQuery);
+
+  // 3. Tìm trong DB
+  const word = await findWordByQuery(normalized);
+
+  // 4. Không tìm thấy → trả lỗi 404
+  if (!word) {
+    throw new AppError(`Word "${normalized}" not found`, 'NOT_FOUND', 404);
+  }
+
+  // 5. Tăng search_count
+  await incrementSearchCount(normalized);
+
+  return word;
 }


### PR DESCRIPTION
Closes #8

## What I did
- Repository: thêm findWordByQuery để tìm từ theo text (case-insensitive)
- Repository: thêm incrementSearchCount để tăng search_count mỗi khi tra từ
- Service: validate query không rỗng, normalize input, xử lý 404 khi không tìm thấy
- Route: thêm GET /word?q= vào vocabulary.route.ts
- Tests: viết unit test cho service và integration test cho route

## Acceptance Criteria
- ✅ Returns correct word
- ✅ search_count increments
- ✅ Handles missing word gracefully (404)